### PR TITLE
Actually return an error for unknown symbol

### DIFF
--- a/quote/client.go
+++ b/quote/client.go
@@ -2,6 +2,7 @@ package quote
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	finance "github.com/piquette/finance-go"
@@ -61,6 +62,10 @@ func GetHistoricalQuote(symbol string, month int, day int, year int) (*finance.C
 // Get returns an Quote quote that matches the parameters specified.
 func Get(symbol string) (*finance.Quote, error) {
 	i := List([]string{symbol})
+
+	if i.Count() == 0 {
+		return nil, fmt.Errorf("Can't find quote for symbol: %s", symbol)
+	}
 
 	if !i.Next() {
 		return nil, i.Err()


### PR DESCRIPTION
`quote.Get` of an inexistent symbol should return a non nil error.
This does not happen....
To repro ask for a quote from a un-existant symbol:

```golang {.lineNumbers}
package main

import (
  "fmt"

  "github.com/piquette/finance-go/quote"
)

func main() {
  q, err := quote.Get("FOOAASDADSAS") // <---- panic here because both `q` and `err` are `nil` 
  if err != nil {
    panic(err)
  }
  fmt.Printf("RegulardMarketPrice: %# +v", q.RegularMarketPrice)
}

```

This will panic:

```
$ go run .
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x620b2e]

goroutine 1 [running]:
main.main()
        /home/pallotron/projects/example/ticker-quote.go:14 +0x2e
exit status 2
[Exit code 1 @ 10:12:01]
```

`get.Quote` should return an error in this case.