### PR TITLE
Fixes get cookie crumbs

### DIFF
--- a/crypto/client.go
+++ b/crypto/client.go
@@ -83,7 +83,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/equity/client.go
+++ b/equity/client.go
@@ -83,7 +83,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/etf/client.go
+++ b/etf/client.go
@@ -83,7 +83,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/examples/main.go
+++ b/examples/main.go
@@ -2,47 +2,172 @@ package main
 
 import (
 	"fmt"
+	"github.com/piquette/finance-go/chart"
+	"github.com/piquette/finance-go/crypto"
+	"github.com/piquette/finance-go/datetime"
+	"github.com/piquette/finance-go/equity"
+	"github.com/piquette/finance-go/etf"
+	"github.com/piquette/finance-go/forex"
+	"github.com/piquette/finance-go/mutualfund"
 	"github.com/piquette/finance-go/options"
+	"github.com/piquette/finance-go/quote"
 )
 
 // This file lists several usage examples of this library
 // and can be used to verify behavior.
 func main() {
 
-	iter := options.GetStraddle("AAPL")
+	// Basic options example.
+	// --------------------
+	{
+		fmt.Println("Options stradle example\n====================\n")
+		iter := options.GetStraddle("AAPL")
 
-	fmt.Println(iter.Meta())
+		fmt.Println(iter.Meta())
 
-	for iter.Next() {
-		fmt.Println(iter.Straddle().Strike)
-	}
-	if iter.Err() != nil {
-		fmt.Println(iter.Err())
+		for iter.Next() {
+			fmt.Println(iter.Straddle().Strike)
+		}
+		if iter.Err() != nil {
+			fmt.Println(iter.Err())
+		}
+		fmt.Println()
 	}
 
 	// Basic quote example.
 	// --------------------
-	// q, err := quote.Get("SPY")
-	// if err != nil {
-	// 	fmt.Println(err)
-	// } else {
-	// 	fmt.Println(q)
-	// }
+	{
+		fmt.Println("Quote example\n====================\n")
+		q, err := quote.Get("GOOG")
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(q)
+		}
+		fmt.Println()
+	}
 
 	// Basic chart example.
 	// --------------------
-	// params := &chart.Params{
-	// 	Symbol:   "TWTR",
-	// 	Interval: datetime.OneHour,
-	// }
-	// iter := chart.Get(params)
-	//
-	// for iter.Next() {
-	// 	b := iter.Bar()
-	// 	fmt.Println(datetime.FromUnix(b.Timestamp))
-	//
-	// }
-	// if iter.Err() != nil {
-	// 	fmt.Println(iter.Err())
-	// }
+	{
+		fmt.Println("Chart example\n====================\n")
+		params := &chart.Params{
+			Symbol:   "GOOG",
+			Interval: datetime.OneHour,
+		}
+		iter := chart.Get(params)
+
+		for iter.Next() {
+			b := iter.Bar()
+			fmt.Println(datetime.FromUnix(b.Timestamp))
+
+		}
+		if iter.Err() != nil {
+			fmt.Println(iter.Err())
+		}
+		fmt.Println()
+	}
+
+	// Basic crypto example.
+	// --------------------
+	{
+		fmt.Println("Crypto example\n====================\n")
+		q, err := crypto.Get("BTC-USD")
+
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(q)
+		}
+		fmt.Println()
+	}
+
+	// Basic equity example.
+	// --------------------
+	{
+		fmt.Println("Equity example\n====================\n")
+		symbols := []string{"AAPL", "GOOG", "MSFT"}
+		iter := equity.List(symbols)
+
+		if iter.Err() != nil {
+			fmt.Println(iter.Err())
+			fmt.Println()
+		} else {
+			for iter.Next() {
+				q := iter.Equity()
+				fmt.Println(q)
+				fmt.Println()
+			}
+		}
+	}
+
+	// Basic ETF example.
+	// --------------------
+	{
+		fmt.Println("ETF example\n====================\n")
+		q, err := etf.Get("SPY")
+
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(q)
+		}
+		fmt.Println()
+	}
+
+	// Basic forex example.
+	// --------------------
+	{
+		fmt.Println("Forex example\n====================\n")
+		q, err := forex.Get("CADUSD=X")
+
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(q)
+		}
+		fmt.Println()
+	}
+
+	// Basic future example.
+	// --------------------
+	{
+		fmt.Println("Future example\n====================\n")
+		q, err := forex.Get("CL=F")
+
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(q)
+		}
+		fmt.Println()
+	}
+
+	// Basic index example.
+	// --------------------
+	{
+		fmt.Println("Index example\n====================\n")
+		q, err := forex.Get("^DJI")
+
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(q)
+		}
+		fmt.Println()
+	}
+
+	// Basic mutual fund example.
+	// --------------------
+	{
+		fmt.Println("Mutual fund example\n====================\n")
+		q, err := mutualfund.Get("FMAGX")
+
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(q)
+		}
+		fmt.Println()
+	}
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/piquette/finance-go/chart"
 	"github.com/piquette/finance-go/crypto"
 	"github.com/piquette/finance-go/datetime"
 	"github.com/piquette/finance-go/equity"
 	"github.com/piquette/finance-go/etf"
 	"github.com/piquette/finance-go/forex"
+	"github.com/piquette/finance-go/future"
+	"github.com/piquette/finance-go/index"
 	"github.com/piquette/finance-go/mutualfund"
 	"github.com/piquette/finance-go/options"
 	"github.com/piquette/finance-go/quote"
@@ -20,7 +23,8 @@ func main() {
 	// Basic options example.
 	// --------------------
 	{
-		fmt.Println("Options stradle example\n====================\n")
+		fmt.Println("Options stradle example\n====================")
+		fmt.Println()
 		iter := options.GetStraddle("AAPL")
 
 		fmt.Println(iter.Meta())
@@ -37,7 +41,8 @@ func main() {
 	// Basic quote example.
 	// --------------------
 	{
-		fmt.Println("Quote example\n====================\n")
+		fmt.Println("Quote example\n====================")
+		fmt.Println()
 		q, err := quote.Get("GOOG")
 		if err != nil {
 			fmt.Println(err)
@@ -50,7 +55,8 @@ func main() {
 	// Basic chart example.
 	// --------------------
 	{
-		fmt.Println("Chart example\n====================\n")
+		fmt.Println("Chart example\n====================")
+		fmt.Println()
 		params := &chart.Params{
 			Symbol:   "GOOG",
 			Interval: datetime.OneHour,
@@ -71,7 +77,8 @@ func main() {
 	// Basic crypto example.
 	// --------------------
 	{
-		fmt.Println("Crypto example\n====================\n")
+		fmt.Println("Crypto example\n====================")
+		fmt.Println()
 		q, err := crypto.Get("BTC-USD")
 
 		if err != nil {
@@ -85,7 +92,8 @@ func main() {
 	// Basic equity example.
 	// --------------------
 	{
-		fmt.Println("Equity example\n====================\n")
+		fmt.Println("Equity example\n====================")
+		fmt.Println()
 		symbols := []string{"AAPL", "GOOG", "MSFT"}
 		iter := equity.List(symbols)
 
@@ -104,7 +112,8 @@ func main() {
 	// Basic ETF example.
 	// --------------------
 	{
-		fmt.Println("ETF example\n====================\n")
+		fmt.Println("ETF example\n====================")
+		fmt.Println()
 		q, err := etf.Get("SPY")
 
 		if err != nil {
@@ -118,7 +127,8 @@ func main() {
 	// Basic forex example.
 	// --------------------
 	{
-		fmt.Println("Forex example\n====================\n")
+		fmt.Println("Forex example\n====================")
+		fmt.Println()
 		q, err := forex.Get("CADUSD=X")
 
 		if err != nil {
@@ -132,8 +142,9 @@ func main() {
 	// Basic future example.
 	// --------------------
 	{
-		fmt.Println("Future example\n====================\n")
-		q, err := forex.Get("CL=F")
+		fmt.Println("Future example\n====================")
+		fmt.Println()
+		q, err := future.Get("CL=F")
 
 		if err != nil {
 			fmt.Println(err)
@@ -146,8 +157,9 @@ func main() {
 	// Basic index example.
 	// --------------------
 	{
-		fmt.Println("Index example\n====================\n")
-		q, err := forex.Get("^DJI")
+		fmt.Println("Index example\n====================")
+		fmt.Println()
+		q, err := index.Get("^DJI")
 
 		if err != nil {
 			fmt.Println(err)
@@ -160,7 +172,8 @@ func main() {
 	// Basic mutual fund example.
 	// --------------------
 	{
-		fmt.Println("Mutual fund example\n====================\n")
+		fmt.Println("Mutual fund example\n====================")
+		fmt.Println()
 		q, err := mutualfund.Get("FMAGX")
 
 		if err != nil {

--- a/examples/main.go
+++ b/examples/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/piquette/finance-go/options"
 )
 
@@ -10,7 +9,7 @@ import (
 // and can be used to verify behavior.
 func main() {
 
-	iter := options.GetStraddle("TWTR")
+	iter := options.GetStraddle("AAPL")
 
 	fmt.Println(iter.Meta())
 

--- a/finance.go
+++ b/finance.go
@@ -197,18 +197,18 @@ func fetchCookies() (string, time.Time, error) {
 	var expiry = time.Now().AddDate(10, 0, 0)
 
 	for _, cookie := range response.Cookies() {
-		var unixTime = cookie.Expires.Unix()
 
-		// Skip invalid cookies
-		if unixTime <= 0 {
+		if cookie.MaxAge <= 0 {
 			continue
 		}
+
+		cookieExpiry := time.Now().Add(time.Duration(cookie.MaxAge) * time.Second)
 
 		if cookie.Name != "AS" {
 			result += cookie.Name + "=" + cookie.Value + "; "
 			// set expiry to the latest cookie expiry if smaller than the current expiry
-			if cookie.Expires.Before(expiry) {
-				expiry = cookie.Expires
+			if cookie.Expires.Before(cookieExpiry) {
+				expiry = cookieExpiry
 			}
 		}
 	}

--- a/finance.go
+++ b/finance.go
@@ -19,7 +19,7 @@ type Printfer interface {
 	Printf(format string, v ...interface{})
 }
 
-// init sets inital logger defaults.
+// init sets initial logger defaults.
 func init() {
 	Logger = log.New(os.Stderr, "", log.LstdFlags)
 }

--- a/finance.go
+++ b/finance.go
@@ -193,8 +193,8 @@ func fetchCookies() (string, time.Time, error) {
 	defer response.Body.Close()
 
 	var result string
-	// create a variable expiry that is one year in the future
-	var expiry = time.Now().AddDate(1, 0, 0)
+	// create a variable expiry that is ten years in the future
+	var expiry = time.Now().AddDate(10, 0, 0)
 
 	for _, cookie := range response.Cookies() {
 		var unixTime = cookie.Expires.Unix()

--- a/forex/client.go
+++ b/forex/client.go
@@ -83,7 +83,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/form/form.go
+++ b/form/form.go
@@ -555,14 +555,14 @@ func (f *Values) Get(key string) []string {
 // a cohesive way. For example, an array of maps in Rack is encoded with a
 // string like:
 //
-//     arr[][foo]=foo0&arr[][bar]=bar0&arr[][foo]=foo1&arr[][bar]=bar1
+//	arr[][foo]=foo0&arr[][bar]=bar0&arr[][foo]=foo1&arr[][bar]=bar1
 //
 // Because url.Values is a map, values will be handled in a way that's grouped
 // by their key instead of in the order they were added. Therefore the above
 // may by encoded to something like (maps are unordered so the actual result is
 // somewhat non-deterministic):
 //
-//     arr[][foo]=foo0&arr[][foo]=foo1&arr[][bar]=bar0&arr[][bar]=bar1
+//	arr[][foo]=foo0&arr[][foo]=foo1&arr[][bar]=bar0&arr[][bar]=bar1
 //
 // And thus result in an incorrect request.
 func (f *Values) ToValues() url.Values {

--- a/future/client.go
+++ b/future/client.go
@@ -83,7 +83,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/piquette/finance-go
 go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1
-	github.com/pmezard/go-difflib v1.0.0
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
 	github.com/stretchr/testify v1.2.2
 )

--- a/index/client.go
+++ b/index/client.go
@@ -83,7 +83,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/mutualfund/client.go
+++ b/mutualfund/client.go
@@ -83,7 +83,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/option/client.go
+++ b/option/client.go
@@ -83,7 +83,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/options/client.go
+++ b/options/client.go
@@ -87,7 +87,7 @@ func (c Client) GetStraddleP(params *Params) *StraddleIter {
 	return &StraddleIter{iter.New(body, func(b *form.Values) (meta interface{}, values []interface{}, err error) {
 
 		resp := response{}
-		err = c.B.Call("v6/finance/options/"+params.UnderlyingSymbol, body, params.Context, &resp)
+		err = c.B.Call("/v7/finance/options/"+params.UnderlyingSymbol, body, params.Context, &resp)
 		if err != nil {
 			return
 		}

--- a/quote/client.go
+++ b/quote/client.go
@@ -106,7 +106,7 @@ func (c Client) ListP(params *Params) *Iter {
 	return &Iter{iter.New(body, func(b *form.Values) (interface{}, []interface{}, error) {
 
 		resp := response{}
-		err := c.B.Call("/v6/finance/quote", body, params.Context, &resp)
+		err := c.B.Call("/v7/finance/quote", body, params.Context, &resp)
 		if err != nil {
 			err = finance.CreateRemoteError(err)
 		}

--- a/quote/client_test.go
+++ b/quote/client_test.go
@@ -79,5 +79,5 @@ func TestGetBadQuote(t *testing.T) {
 
 	q, err := Get("TEST")
 	assert.Nil(t, q)
-	assert.Nil(t, err)
+	assert.Equal(t, "Can't find quote for symbol: TEST", err.Error())
 }


### PR DESCRIPTION
This fixes Issue #25 

We now fetch cookies and crumb first to be fed in later calls. This code was lifted and adapted from [mop](https://github.com/mop-tracker/mop) and pretty much replicates [their fix](https://github.com/mop-tracker/mop/commit/c66e33ace3ff5d9c74f060830c9f04ae266d6e8f).

This branch also contains a fix for a test that was broken. It expected no error when fetching a non exiting symbol, but there is actually an error being generated.

The example code was also augmented with pretty much all types of calls that can be made to the Yahoo! API. This was used to make sure the fix was actually working.